### PR TITLE
Add a symbol for no solutions

### DIFF
--- a/pkg/bot/leaderboard.go
+++ b/pkg/bot/leaderboard.go
@@ -57,7 +57,7 @@ func (bot *Bot) GenerateLeaderboardEmbed(guildId string) (*discordgo.MessageEmbe
 		for dayNumber := 1; dayNumber <= 25; dayNumber++ {
 			day, ok := member.CompletionDayLevel[strconv.Itoa(dayNumber)]
 			if !ok {
-				stars += " "
+				stars += "─"
 				continue
 			}
 			_, star1 := day["1"]


### PR DESCRIPTION
Use the ─ symbol (U+2500) for no solution. Example:
```
Robin: ★★★★☆★★★★  
Bruce: ★★★★★★★★★
Clark: ★★★★☆★☆──
Barry: ★☆──☆────
```
It's not perfect, but readability would be improved.